### PR TITLE
Fix findTransformECC error

### DIFF
--- a/src/tracktor/tracker.py
+++ b/src/tracktor/tracker.py
@@ -206,7 +206,7 @@ class Tracker:
 			try:
 				cc, warp_matrix = cv2.findTransformECC(im1_gray, im2_gray, warp_matrix, self.warp_mode, criteria)
 			except:
-				cc, warp_matrix = cv2.findTransformECC(im1_gray, im2_gray, warp_matrix, self.warp_mode, criteria, None, 1)
+				cc, warp_matrix = cv2.findTransformECC(im1_gray, im2_gray, warp_matrix, self.warp_mode, criteria, None, 5)
 			warp_matrix = torch.from_numpy(warp_matrix)
 
 			for t in self.tracks:


### PR DESCRIPTION
In some OpenCV library, it is needed to input parameter inputMask and gaussFiltSize for findTransformECC.
I've fixed it following [this comment](https://answers.opencv.org/question/212409/error-in-findtransformecc/?answer=212572#post-id-212572).
And, from [official OpenCV Github](https://github.com/opencv/opencv/blob/a41b79d43e432d7447e90304ea62478c2c39af6d/modules/video/src/ecc.cpp) and the [document site](https://docs.opencv.org/3.4/dc/d6b/group__video__track.html#ga1aa357007eaec11e9ed03500ecbcbe47), I've set gaussFiltSize as 5.