### PR TITLE
Fix colormap generation and output folder name

### DIFF
--- a/experiments/scripts/test_tracktor.py
+++ b/experiments/scripts/test_tracktor.py
@@ -74,6 +74,7 @@ def main(module_name, name, seed, obj_detect_models, reid_models,
     with open(sacred_config, 'w') as outfile:
         yaml.dump(copy.deepcopy(_config), outfile, default_flow_style=False)
 
+    dataset_name = dataset
     dataset = Datasets(dataset)
     reid_models, obj_detect_models, dataset = add_reid_config(reid_models, obj_detect_models, dataset)
 
@@ -164,7 +165,7 @@ def main(module_name, name, seed, obj_detect_models, reid_models,
             plot_sequence(
                 results,
                 seq,
-                osp.join(output_dir, str(dataset), str(seq)),
+                osp.join(output_dir, str(dataset_name), str(seq)),
                 write_images)
 
     if time_total:

--- a/src/tracktor/utils.py
+++ b/src/tracktor/utils.py
@@ -164,7 +164,7 @@ def plot_sequence(tracks, data_loader, output_dir, write_images):
     if not osp.exists(output_dir):
         os.makedirs(output_dir)
 
-    cmap = rand_cmap(len(tracks), type='bright', first_color_black=False, last_color_black=False)
+    cmap = rand_cmap(len(tracks)+1, type='bright', first_color_black=False, last_color_black=False)
 
     for frame_id, frame_data  in enumerate(tqdm.tqdm(data_loader)):
         img_path = frame_data['img_path']


### PR DESCRIPTION
(1) If there is only a single track (`len(tracks)=1`) in an image sequence, writing the output images fails due to issues with the generated colormap
```
ERROR - test_tracktor - Failed after 0:00:46!
Traceback (most recent calls WITHOUT Sacred internals):
  File "experiments/scripts/test_tracktor.py", line 165, in main
    write_images)
  File "/databricks/driver/tracking_wo_bnw/src/tracktor/utils.py", line 200, in plot_sequence
    color=cmap(track_id)
  File "/databricks/conda/envs/databricks-ml-gpu/lib/python3.7/site-packages/matplotlib/colors.py", line 612, in __call__
    self._init()
  File "/databricks/conda/envs/databricks-ml-gpu/lib/python3.7/site-packages/matplotlib/colors.py", line 899, in _init
    self.N, self._segmentdata['red'], self._gamma)
  File "/databricks/conda/envs/databricks-ml-gpu/lib/python3.7/site-packages/matplotlib/colors.py", line 516, in _create_lookup_table
    "data mapping points must start with x=0 and end with x=1")
ValueError: data mapping points must start with x=0 and end with x=1
```
Generating the colormap for `len(tracks)+1` labels solves this problem.

(2) In `test_tracktor.py` the `dataset` variable is a string at first, then a `Factory` object is assigned to this variable.
Hence, the output folders for `plot_sequence()` are named as `<object Factory at 0xsomething>` - fixed by using an intermediate variable.